### PR TITLE
Add npm publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
+        description: Package version (tag name, e.g. v1.0.0)
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.version }}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access=public

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.idea
+.vscode
 node_modules

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,5 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.idea
+.github


### PR DESCRIPTION
Add github workflow for publishing package to the npm registry. Ignore .idea, .vscode.